### PR TITLE
remove: support of binary data

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,6 @@ const redisConn = await Deno.connect({ port: 6379 });
 await writeCommand(redisConn, ["SHUTDOWN"]);
 ```
 
-### Raw data
-
-```ts
-import {
-  sendCommand,
-  sendCommandRawReply,
-} from "https://deno.land/x/r2d2/mod.ts";
-
-const redisConn = await Deno.connect({ port: 6379 });
-
-const value = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
-
-// Returns "OK"
-await sendCommand(redisConn, ["SET", "binary", value]);
-
-// Returns Uint8Array(8) [0, 1, 2, 1, 2, 1, 2, 3]
-await sendCommandRawReply(redisConn, ["GET", "binary"]);
-```
-
 ### Pipelining
 
 ```ts

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "redis:start": "rm -f dump.rdb && redis-server --daemonize yes",
-    "test": "deno task redis:start && rm -rf cov && deno test --allow-net=127.0.0.1:6379 --trace-ops --coverage=cov",
+    "test": "deno task redis:start && rm -rf cov && deno test --allow-net=127.0.0.1:6379 --trace-ops --coverage=cov --doc",
     "bench": "deno task redis:start && deno --unstable bench --allow-net=127.0.0.1:6379",
     "coverage": "deno coverage cov --exclude='test.ts|deps.ts' --lcov --output=cov.lcov"
   },

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,5 @@
 export { writeAll } from "https://deno.land/std@0.154.0/streams/conversion.ts";
-export {
-  BufReader,
-  type ReadLineResult,
-} from "https://deno.land/std@0.154.0/io/buffer.ts";
+export { BufReader } from "https://deno.land/std@0.154.0/io/buffer.ts";
 export { concat } from "https://deno.land/std@0.154.0/bytes/mod.ts";
 
 /** Testing */

--- a/mod.ts
+++ b/mod.ts
@@ -38,6 +38,10 @@ function createRequest(command: Command): Uint8Array {
  *
  * Example:
  * ```ts
+ * import { writeCommand } from "https://deno.land/x/r2d2/mod.ts";
+ *
+ * const redisConn = await Deno.connect({ port: 6379 });
+ *
  * await writeCommand(redisConn, ["SHUTDOWN"]);
  * ```
  */
@@ -122,6 +126,8 @@ async function readReply(bufReader: BufReader): Promise<Reply> {
  *
  * Example:
  * ```ts
+ * import { sendCommand } from "https://deno.land/x/r2d2/mod.ts";
+ *
  * const redisConn = await Deno.connect({ port: 6379 });
  *
  * // Returns "OK"
@@ -144,6 +150,8 @@ export async function sendCommand(
  *
  * Example:
  * ```ts
+ * import { pipelineCommands } from "https://deno.land/x/r2d2/mod.ts";
+ *
  * const redisConn = await Deno.connect({ port: 6379 });
  *
  * // Returns [1, 2, 3, 4]
@@ -169,6 +177,10 @@ export async function pipelineCommands(
  *
  * Example:
  * ```ts
+ * import { writeCommand, listenReplies } from "https://deno.land/x/r2d2/mod.ts";
+ *
+ * const redisConn = await Deno.connect({ port: 6379 });
+ *
  * await writeCommand(redisConn, ["SUBSCRIBE", "mychannel"]);
  *
  * for await (const reply of listenReplies(redisConn)) {

--- a/test.ts
+++ b/test.ts
@@ -5,7 +5,6 @@ import {
   pipelineCommands,
   type Reply,
   sendCommand,
-  sendCommandRawReply,
   writeCommand,
 } from "./mod.ts";
 
@@ -73,18 +72,6 @@ Deno.test("sendCommand works with transactions", async () => {
   await sendCommandTest(["INCR", "FOO"], "QUEUED");
   await sendCommandTest(["INCR", "BAR"], "QUEUED");
   await sendCommandTest(["EXEC"], [1, 1]);
-});
-
-Deno.test("sendCommandRawReply works", async () => {
-  const value = new Uint8Array([0, 1, 2, 1, 2, 1, 2, 3]);
-  await sendCommandTest(["SET", "binary", value], "OK");
-  assertEquals(await sendCommandRawReply(redisConn, ["GET", "binary"]), value);
-});
-
-Deno.test("sendCommandRawReply throws on non-bulk-string reply", async () => {
-  await assertRejects(async () =>
-    await sendCommandRawReply(redisConn, ["PING"])
-  );
 });
 
 Deno.test("pipelineCommands works", async () => {


### PR DESCRIPTION
Dropping support of binary data simplifies the codebase, which still supports most uses cases.
