### PR TITLE
refactor: reply tests

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -8,5 +8,6 @@ export {
   assertEquals,
   assertRejects,
 } from "https://deno.land/std@0.158.0/testing/asserts.ts";
+export { StringReader } from "https://deno.land/std@0.158.0/io/readers.ts";
 
 export { connect } from "https://deno.land/x/redis@v0.27.0/redis.ts";

--- a/src/reply.ts
+++ b/src/reply.ts
@@ -23,7 +23,7 @@ function readSimpleString(line: string): string {
 }
 
 async function readError(line: string): Promise<never> {
-  return await Promise.reject(removePrefix(line));
+  return await Promise.reject(removePrefix(line).slice(4));
 }
 
 function readInteger(line: string): number {

--- a/src/request_test.ts
+++ b/src/request_test.ts
@@ -1,0 +1,71 @@
+import { assertRejects } from "https://deno.land/std@0.158.0/testing/asserts.ts";
+import { assertEquals, BufReader, StringReader } from "../deps.ts";
+import { readReply, type Reply } from "./reply.ts";
+
+async function readReplyTest(output: string, expected: Reply) {
+  assertEquals(
+    await readReply(new BufReader(new StringReader(output))),
+    expected,
+  );
+}
+
+async function readReplyRejectTest(output: string, expected: string) {
+  await assertRejects(
+    async () => await readReply(new BufReader(new StringReader(output))),
+    expected,
+  );
+}
+
+/** RESP v2 */
+
+Deno.test("simple string", async () => {
+  await readReplyTest("+OK\r\n", "OK");
+});
+
+Deno.test("integer", async () => {
+  await readReplyTest(":42\r\n", 42);
+});
+
+Deno.test("bulk string", async () => {
+  await readReplyTest("$5\r\nhello\r\n", "hello");
+  /** Empty bulk string */
+  await readReplyTest("$0\r\n\r\n", "");
+  /** Null bulk string */
+  await readReplyTest("$-1\r\n", null);
+});
+
+Deno.test("array", async () => {
+  await readReplyTest("*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n", [
+    "hello",
+    "world",
+  ]);
+  await readReplyTest("*3\r\n:1\r\n:2\r\n:3\r\n", [1, 2, 3]);
+  /** Empty array */
+  await readReplyTest("*0\r\n", []);
+  /** Null array */
+  await readReplyTest("*-1\r\n", null);
+  /** Null elements in array */
+  await readReplyTest("*3\r\n$5\r\nhello\r\n$-1\r\n$5\r\nworld\r\n", [
+    "hello",
+    null,
+    "world",
+  ]);
+});
+
+Deno.test("simple error", async () => {
+  await readReplyRejectTest(
+    "-ERR this is the error description\r\n",
+    "this is the error description",
+  );
+});
+
+/** RESP3 */
+
+Deno.test("null", async () => {
+  await readReplyTest("_\r\n", null);
+});
+
+Deno.test("boolean", async () => {
+  await readReplyTest("#t\r\n", true);
+  await readReplyTest("#f\r\n", false);
+});

--- a/test.ts
+++ b/test.ts
@@ -22,55 +22,6 @@ async function sendCommandTest(
   assertEquals(await sendCommand(redisConn, command), expected);
 }
 
-Deno.test("RESP v2", async (t) => {
-  await t.step(
-    "simple string",
-    async () => await sendCommandTest(["PING"], "PONG"),
-  );
-
-  await t.step("error", async () => {
-    await assertRejects(async () =>
-      await sendCommand(redisConn, ["helloworld"])
-    );
-  });
-
-  await t.step("integer", async () => {
-    await sendCommandTest(["INCR", "integer"], 1);
-    await sendCommandTest(["INCR", "integer"], 2);
-  });
-
-  await t.step("bulk string", async () => {
-    await sendCommand(redisConn, ["SET", "big ups", "west side massive"]);
-    await sendCommandTest(["GET", "big ups"], "west side massive");
-  });
-
-  await t.step("null", async () => {
-    await sendCommandTest(["GET", "nonexistant"], null);
-  });
-
-  await t.step("array", async () => {
-    await sendCommand(redisConn, [
-      "HSET",
-      "hash",
-      "hello",
-      "world",
-      "integer",
-      13,
-    ]);
-    await sendCommandTest([
-      "HMGET",
-      "hash",
-      "hello",
-      "integer",
-      "nonexistant",
-    ], ["world", "13", null]);
-    /** Empty array */
-    await sendCommandTest(["HGETALL", "nonexistant"], []);
-    /** Null array */
-    await sendCommandTest(["BLPOP", "list", 1], null);
-  });
-});
-
 Deno.test("methods", async (t) => {
   await t.step("transactions", async () => {
     await sendCommandTest(["MULTI"], "OK");
@@ -104,20 +55,6 @@ Deno.test("methods", async (t) => {
       done: false,
     });
   });
-});
-
-Deno.test("RESP3", async (t) => {
-  await sendCommand(redisConn, ["HELLO", 3]);
-
-  await t.step("boolean", async () => {
-    await sendCommandTest(["EVAL", "redis.setresp(3); return true", 0], true);
-    await sendCommandTest(["EVAL", "redis.setresp(3); return false", 0], false);
-  });
-
-  await t.step(
-    "null",
-    async () => await sendCommandTest(["GET", "null"], null),
-  );
 });
 
 /** This test must be last */


### PR DESCRIPTION
Removes the dependency on the Redis server and instead directly tests the string buffer reader.