### PR TITLE
feat: `test:dev` and `bench:dev` tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,8 @@ Before submitting a pull request, please run:
 
 1. `deno fmt`
 2. `deno lint`
-3. `deno task redis:start && deno task test` and ensure all tests pass
-4. `deno task redis:start && deno task bench` and ensure performance hasn't
-   degraded
+3. `deno task test:dev` and ensure all tests pass
+4. `deno task bench:dev` and ensure performance hasn't degraded
 
 > Note: Redis must be installed on your local machine. For installation
 > instructions, see [here](https://redis.io/docs/getting-started/installation/).
@@ -232,7 +231,7 @@ summary
    2.91x faster than npm:redis
 ```
 
-> Node: Results were produced using `deno task redis:start && deno task bench`.
+> Node: Results were produced using `deno task bench:dev`.
 
 ### Size
 

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,9 @@
   "tasks": {
     "redis:start": "rm -f dump.rdb && redis-server --daemonize yes",
     "test": "deno test --allow-net --trace-ops --coverage=cov --doc --parallel",
+    "test:dev": "deno task redis:start && deno task test",
     "bench": "deno bench --allow-net --allow-env",
+    "bench:dev": "deno task redis:start && deno task bench",
     "coverage": "deno coverage cov --exclude='test.ts' --lcov --output=cov.lcov"
   },
   "fmt": {


### PR DESCRIPTION
This change makes `test:dev` and `bench:dev` tasks available, which makes local development a little easier.