### PR TITLE
feat: use imports within Deno config file

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,7 @@
 {
-  "importMap": "import_map.json",
+  "imports": {
+    "https://deno.land/x/r2d2@$VERSION/": "./"
+  },
   "tasks": {
     "redis:start": "rm -f dump.rdb && redis-server --daemonize yes",
     "test": "deno test --allow-net --trace-ops --coverage=cov --doc --parallel",

--- a/import_map.json
+++ b/import_map.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "https://deno.land/x/r2d2@$VERSION/": "./"
-  }
-}


### PR DESCRIPTION
This change moves imports from `import_map.json` to `deno.json` thanks to [the functionality introduced in Deno 1.30](https://deno.com/blog/v1.30#denojson-becomes-an-import-map).