### PR TITLE
refactor: use npm specifiers for benchmarks

### DIFF
--- a/bench.ts
+++ b/bench.ts
@@ -1,6 +1,6 @@
-import { connect } from "https://deno.land/x/redis@v0.29.2/mod.ts";
-import { Redis } from "https://esm.sh/ioredis@5.3.1";
-import nodeRedis from "https://esm.sh/redis@4.6.5";
+import { connect } from "https://deno.land/x/redis@v0.29.3/mod.ts";
+import { Redis } from "npm:ioredis@5.3.1";
+import nodeRedis from "npm:redis@4.6.5";
 
 import { pipelineCommands, sendCommand } from "./mod.ts";
 


### PR DESCRIPTION
Use npm specifiers instead of esm.sh.