### PR TITLE
fix: shutdown Redis server after failed tests

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,7 +5,7 @@
   "tasks": {
     "redis:start": "redis-server --save \"\" --appendonly no --daemonize yes",
     "test": "deno test --allow-net --trace-ops --coverage=cov --doc --parallel",
-    "test:dev": "deno task redis:start && deno task test",
+    "test:dev": "deno task redis:start && deno task test || redis-cli SHUTDOWN",
     "bench": "deno bench --allow-net --allow-env",
     "bench:dev": "deno task redis:start && deno task bench",
     "cov:clean": "rm -rf cov html_cov cov.lcov",


### PR DESCRIPTION
Previously, the tests would save data to the database and then fail. Subsequent tests would then fail due to the database not being clean.